### PR TITLE
Catch redis errors

### DIFF
--- a/redislog/handlers.py
+++ b/redislog/handlers.py
@@ -45,6 +45,7 @@ class RedisHandler(logging.Handler):
         """
         Publish record to redis logging channel
         """
-        self.redis_client.publish(self.channel, self.format(record))
-        
-
+        try :
+            self.redis_client.publish(self.channel, self.format(record))
+        except redis.RedisError:
+            pass


### PR DESCRIPTION
If redis is down, the logging framework shouldn't raise an exception.
There is probably a proper way to log an exception from a logging handler, I just don't know what it is...
